### PR TITLE
Fix display of post-index writeback operands

### DIFF
--- a/src/armv7.rs
+++ b/src/armv7.rs
@@ -1728,10 +1728,7 @@ fn format_reg_imm_mem<T: fmt::Write, Y: YaxColors>(f: &mut T, Rn: Reg, imm: u16,
             (true, false) => {
                 write!(f, "[{}, {}{:#x}]", reg_name_colorize(Rn, colors), op, imm)
             },
-            (false, true) => {
-                unreachable!("I don't know how to render an operand with postindex and wback==true, this seems like it should be LDRT");
-            },
-            (false, false) => {
+            (false, _) => {
                 write!(f, "[{}], {}{:#x}", reg_name_colorize(Rn, colors), op, imm)
             }
         }

--- a/test/armv7/thumb.rs
+++ b/test/armv7/thumb.rs
@@ -3579,6 +3579,10 @@ fn test_decode_str_32b_cases() {
         &[0xe3, 0xe9, 0x7e, 0x5a],
         "strd r5, r10, [r3, 0x1f8]!"
     );
+    test_display(
+        &[0x41, 0xf8, 0x04, 0x2b],
+        "str.w r2, [r1], 0x4"
+    );
 }
 
 #[test]


### PR DESCRIPTION
According to llvm-objdump and the arm arm arm, this should be displayed like `str     r2, [r1], #4`, like the existing non-writeback case (which does not seem to exist in ARMv7-M, so hopefully there's no ambiguity there).