### PR TITLE
fix decoding armv8 a64 hint instructions

### DIFF
--- a/src/armv8/a64.rs
+++ b/src/armv8/a64.rs
@@ -10306,7 +10306,7 @@ impl Decoder<ARMv8> for InstDecoder {
 
                                         match CRn {
                                             0b0010 => {
-                                                let CRm = (word >> 12) & 0xf;
+                                                let CRm = (word >> 8) & 0xf;
                                                 inst.opcode = Opcode::HINT;
                                                 inst.operands = [
                                                     Operand::ControlReg(CRm as u16),

--- a/tests/armv8/a64.rs
+++ b/tests/armv8/a64.rs
@@ -65,7 +65,7 @@ fn test_display_misc() {
     );
     test_display(
         [0x1f, 0x20, 0x03, 0xd5],
-        "esb"
+        "nop"
     );
 }
 
@@ -663,7 +663,7 @@ fn test_decode_chrome_entrypoint() {
     );
     test_display(
         [0x1f, 0x20, 0x03, 0xd5],
-        "esb"
+        "nop"
     );
     test_display(
         [0x20, 0x00, 0x1f, 0xd6],
@@ -4175,7 +4175,7 @@ fn test_openblas_simd_movs() {
 #[test]
 fn test_openblas_misc_ops() {
     const TESTS: &[([u8; 4], &'static str)] = &[
-        ([0x1f, 0x20, 0x03, 0xd5], "esb"), // executes as nop, but also a barrier
+        ([0x1f, 0x20, 0x03, 0xd5], "nop"),
         ([0xbf, 0x3a, 0x03, 0xd5], "dmb ishst"),
         ([0xbf, 0x3b, 0x03, 0xd5], "dmb ish"),
         ([0xdf, 0x3f, 0x03, 0xd5], "isb"),


### PR DESCRIPTION
Reason:

- in code `CRn` and `CRm` variables have the same initialization - it's just weird,
- [developer.arm.com docs](https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/HINT--Hint-instruction-?lang=en).

Not sure, if it's correct, because there are tests for this. Were they taken from somewhere or written by hand?

---

Note: `op2` variable also looks wrong (in docs mask is 0x7), but `Display`-based tests won't show difference
