### PR TITLE
Disable bitvec features to fix no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = ["differential-tests"]
 
 [dependencies]
 yaxpeax-arch = { version = "0.3.1", default-features = false, features = [] }
-bitvec = "1.0.1"
+bitvec = { version = "1.0.1", default-features = false, features = [] }
 "serde" = { version = "1.0", optional = true }
 "serde_derive" = { version = "1.0", optional = true }
 


### PR DESCRIPTION
bitvec currently has `std` enabled by default. It looks like this crate doesn't need _any_ features enabled for it, so we can disable them all.