### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/armv8/a64.rs
+++ b/src/armv8/a64.rs
@@ -3058,7 +3058,7 @@ impl Display for Operand {
                 if *d as i64 as f64 == *d {
                     write!(fmt, "#{:0.1}", d)
                 } else {
-                    write!(fmt, "#{:0.}", d)
+                    write!(fmt, "#{:0}", d)
                 }
             },
             Operand::Imm16(i) => {


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.