### PR TITLE
fix opcode display for ldg

### DIFF
--- a/src/armv8/a64.rs
+++ b/src/armv8/a64.rs
@@ -2535,7 +2535,7 @@ impl Display for Opcode {
             Opcode::TBX => "tbx",
             Opcode::FCADD => "fcadd",
             Opcode::LDGM => "ldgm",
-            Opcode::LDG => "ldm",
+            Opcode::LDG => "ldg",
             Opcode::STGM => "stgm",
             Opcode::STZGM => "stzgm",
             Opcode::STG => "stg",


### PR DESCRIPTION
It's currently displayed as `ldm`.