### PR TITLE
derive Clone and Copy for armv7 instruction

### DIFF
--- a/src/armv7.rs
+++ b/src/armv7.rs
@@ -789,7 +789,7 @@ pub enum Bank {
 }
 
 /// a `armv7` or below instruction.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Instruction {
     /// the condition code for this instruction, defaults to `AL` if the instruction is
     /// unconditional.


### PR DESCRIPTION
Sometimes it's cheaper to clone than do lookup in already disassembled instructions + ARMv8 type has these derived