### PR TITLE
add MCR/MRC decoding for armv7

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,11 @@
 * documentation for how to process `StatusRegMask`
 * fix incorrect decoding of STM pre/post increment for encoding T1
   - "stm" would report preincrement when the semantic is postincrement"
+* postincrement operands should always postincrement
+  - through a comedy of errors, the structured decoding of
+    RegDerefPostindexOffset would report "wback=false", but this operand form
+    always writes back the modified address. the textual decoding of these
+    instructions was correct and continues to be.
 
 ## 0.4.0
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,9 @@
     always writes back the modified address. the textual decoding of these
     instructions was correct and continues to be.
 * a few cases of rejecting valid instructions as `nonconforming` have been fixed
+* branch offsets are consistently represented as their form in terms of linear
+  addresses and offsets. again, no change to display impls, but `Operand`
+  variants describing Branch/BranchThumb offsets are a little more normal now.
 
 ## 0.4.0
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@
     RegDerefPostindexOffset would report "wback=false", but this operand form
     always writes back the modified address. the textual decoding of these
     instructions was correct and continues to be.
+* a few cases of rejecting valid instructions as `nonconforming` have been fixed
 
 ## 0.4.0
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+## 0.5.0
+
+* documentation for how to process `StatusRegMask`
+
 ## 0.4.0
 
 * ARMv7 and A64 `Opcode` and `Operand` are now `#[non_exhaustive]`.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 ## 0.5.0
 
 * documentation for how to process `StatusRegMask`
+* fix incorrect decoding of STM pre/post increment for encoding T1
+  - "stm" would report preincrement when the semantic is postincrement"
 
 ## 0.4.0
 

--- a/src/armv7.rs
+++ b/src/armv7.rs
@@ -1963,11 +1963,6 @@ impl Decoder<ARMv7> for InstDecoder {
                                         } else {
                                             inst.opcode = Opcode::LDRSB;
                                         }
-                                        if self.should_is_must {
-                                            if (word >> 8) & 0b1111 == 0 {
-                                                return Err(DecodeError::Nonconforming);
-                                            }
-                                        }
                                         let Rt = (word >> 12) as u8 & 0b1111;
                                         let Rn = (word >> 16) as u8 & 0b1111;
                                         let imm = (HiOffset << 4) as u16 | LoOffset as u16;
@@ -2032,7 +2027,7 @@ impl Decoder<ARMv7> for InstDecoder {
                                             inst.opcode = Opcode::LDRSH;
                                         }
                                         if self.should_is_must {
-                                            if (word >> 8) & 0b1111 == 0 {
+                                            if (word >> 8) & 0b1111 != 0 {
                                                 return Err(DecodeError::Nonconforming);
                                             }
                                         }
@@ -2084,11 +2079,6 @@ impl Decoder<ARMv7> for InstDecoder {
                                             inst.opcode = Opcode::LDRSHT;
                                         } else {
                                             inst.opcode = Opcode::LDRSH;
-                                        }
-                                        if self.should_is_must {
-                                            if (word >> 8) & 0b1111 == 0 {
-                                                return Err(DecodeError::Nonconforming);
-                                            }
                                         }
                                         let Rt = (word >> 12) as u8 & 0b1111;
                                         let Rn = (word >> 16) as u8 & 0b1111;

--- a/src/armv7.rs
+++ b/src/armv7.rs
@@ -524,6 +524,25 @@ impl CReg {
     }
 }
 
+/// `StatusRegMask` describes the status register mask as encoded in `msr` or `mrs` instructions.
+/// the bit patterns described by this mask are buried in the ARM reference manual, reproduced here
+/// from `B9.3.11 MSR (immediate)`:
+/// > `<spec_reg>` Is one of:
+/// > * `APSR_<bits>`
+/// > * `CPSR_<fields>`
+/// > * `SPSR_<fields>`
+/// > [...]
+/// > `<bits>` Is one of nzcvq, g, or nzcvqg.
+/// > In the A and R profiles:
+/// > * APSR_nzcvq is the same as CPSR_f (mask == '1000')
+/// > * APSR_g is the same as CPSR_s (mask == '0100')
+/// > * APSR_nzcvqg is the same as CPSR_fs (mask == '1100').
+/// >
+/// > `<fields>` Is a sequence of one or more of the following:
+/// > * `c` - `mask<0> = 1' to enable writing of `bits<7:0>` of the destination PSR
+/// > * `x` - `mask<1> = 1' to enable writing of `bits<15:8>` of the destination PSR
+/// > * `s` - `mask<2> = 1' to enable writing of `bits<23:16>` of the destination PSR
+/// > * `f` - `mask<3> = 1' to enable writing of `bits<31:24>` of the destination PSR.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
 #[allow(missing_docs)]
@@ -622,7 +641,7 @@ pub enum Operand {
     /// immediate offset.
     RegShift(RegShift),
     /// a memory access of a register, post-indexed a register shifted by register or immediate.
-    /// the first bool indicates if the shifted-register is added or subtracted ot the base
+    /// the first bool indicates if the shifted-register is added or subtracted to the base
     /// register, while the second bool indicates if the resulting address is written back to the
     /// base register.
     RegDerefPostindexRegShift(Reg, RegShift, bool, bool), // add/sub, wback
@@ -632,19 +651,19 @@ pub enum Operand {
     /// the base register.
     RegDerefPreindexRegShift(Reg, RegShift, bool, bool), // add/sub, wback
     /// a memory access of a register, post-indexed with an immediate. the first bool indicates if
-    /// the shifted-register is added or subtracted ot the base register, while the second bool
+    /// the shifted-register is added or subtracted to the base register, while the second bool
     /// indicates if the resulting address is written back to the base register.
     RegDerefPostindexOffset(Reg, u16, bool, bool), // add/sub, wback
     /// a memory access of a register, pre-indexed with an immediate. the first bool indicates if
-    /// the shifted-register is added or subtracted ot the base register, while the second bool
+    /// the shifted-register is added or subtracted to the base register, while the second bool
     /// indicates if the resulting address is written back to the base register.
     RegDerefPreindexOffset(Reg, u16, bool, bool), // add/sub, wback
     /// a memory access of a register, post-indexed with a register. the first bool indicates if the
-    /// shifted-register is added or subtracted ot the base register, while the second bool
+    /// shifted-register is added or subtracted to the base register, while the second bool
     /// indicates if the resulting address is written back to the base register.
     RegDerefPostindexReg(Reg, Reg, bool, bool), // add/sub, wback
     /// a memory access of a register, pre-indexed with a register. the first bool indicates if the
-    /// shifted-register is added or subtracted ot the base register, while the second bool
+    /// shifted-register is added or subtracted to the base register, while the second bool
     /// indicates if the resulting address is written back to the base register.
     RegDerefPreindexReg(Reg, Reg, bool, bool), // add/sub, wback
     /// a 12-bit immediate, stored in a `u16`.

--- a/src/armv7.rs
+++ b/src/armv7.rs
@@ -2569,6 +2569,16 @@ impl Decoder<ARMv7> for InstDecoder {
                                 ];
                             }
                         }
+                        // TEQ is a two-operand instruction expecting Rd to be 0.
+                        if inst.opcode == Opcode::TEQ || inst.opcode == Opcode::TST || inst.opcode == Opcode::CMP || inst.opcode == Opcode::CMN {
+                            if inst.operands[0] != Operand::Reg(Reg { bits: 0 }) {
+                                return Err(DecodeError::InvalidOperand);
+                            }
+                            inst.operands = [
+                                inst.operands[1], inst.operands[2],
+                                Operand::Nothing, Operand::Nothing
+                            ];
+                        }
                     }
                 }
             },
@@ -2669,8 +2679,35 @@ impl Decoder<ARMv7> for InstDecoder {
                     };
                     if (opcode == 0b0010 || opcode == 0b0100) && Rn == 0b1111 {
                         inst.opcode = Opcode::ADR;
+                        if opcode == 0b0010 {
+                            inst.operands = [
+                                Operand::Reg(Reg::from_u8(Rd)),
+                                Operand::Imm32((-(imm as i32)) as u32),
+                                Operand::Nothing,
+                                Operand::Nothing,
+                            ];
+                        } else {
+                            inst.operands = [
+                                Operand::Reg(Reg::from_u8(Rd)),
+                                Operand::Imm32(imm),
+                                Operand::Nothing,
+                                Operand::Nothing,
+                            ];
+                        }
+                        return Ok(());
                     }
                     match opcode {
+                        0b1000 |
+                        0b1001 |
+                        0b1010 |
+                        0b1011 => {
+                            inst.operands = [
+                                Operand::Reg(Reg::from_u8(Rn)),
+                                Operand::Imm32(imm),
+                                Operand::Nothing,
+                                Operand::Nothing,
+                            ];
+                        }
                         0b1101 => {
                             inst.operands = [
                                 Operand::Reg(Reg::from_u8(Rd)),

--- a/src/armv7.rs
+++ b/src/armv7.rs
@@ -2519,19 +2519,27 @@ impl Decoder<ARMv7> for InstDecoder {
                                     ];
                                 }
                             } else {
-                                if self.should_is_must {
-                                    if opcode == 0b1101 && Rn != 0 {
-                                        // Rn "should" be zero
-                                        return Err(DecodeError::Nonconforming);
+                                if opcode == 0b1101 {
+                                    if self.should_is_must {
+                                        if Rn != 0 {
+                                            // Rn "should" be zero
+                                            return Err(DecodeError::Nonconforming);
+                                        }
                                     }
+                                    inst.operands = [
+                                        Operand::Reg(Reg::from_u8(Rd)),
+                                        Operand::RegShift(RegShift::from_raw(shift_spec)),
+                                        Operand::Nothing,
+                                        Operand::Nothing
+                                    ];
+                                } else {
+                                    inst.operands = [
+                                        Operand::Reg(Reg::from_u8(Rd)),
+                                        Operand::Reg(Reg::from_u8(Rn)),
+                                        Operand::RegShift(RegShift::from_raw(shift_spec)),
+                                        Operand::Nothing
+                                    ];
                                 }
-
-                                inst.operands = [
-                                    Operand::Reg(Reg::from_u8(Rd)),
-                                    Operand::Reg(Reg::from_u8(Rn)),
-                                    Operand::RegShift(RegShift::from_raw(shift_spec)),
-                                    Operand::Nothing
-                                ];
                             }
                         } else {
                     //    known 0 because it and bit 5 are not both 1 --v
@@ -2548,9 +2556,18 @@ impl Decoder<ARMv7> for InstDecoder {
                             // page A5-200 indicates that saturating add and subtract should be
                             // here?
                             if (0b1101 & opcode) == 0b1101 {
+                                if self.should_is_must {
+                                    if Rn != 0 {
+                                        return Err(DecodeError::Nonconforming);
+                                    }
+                                }
                                 // these are all invalid
-                                inst.opcode = Opcode::Invalid;
-                                return Err(DecodeError::InvalidOpcode);
+                                inst.operands = [
+                                    Operand::Reg(Reg::from_u8(Rd)),
+                                    Operand::RegShift(RegShift::from_raw(shift_spec)),
+                                    Operand::Nothing,
+                                    Operand::Nothing,
+                                ];
                             } else {
                                 // TODO: unsure about this RegShift...
                                 inst.operands = [

--- a/src/armv7.rs
+++ b/src/armv7.rs
@@ -1438,8 +1438,8 @@ impl Decoder<ARMv7> for InstDecoder {
                                     Operand::RegDerefPreindexOffset(Reg::from_u8(Rn), (imm8 << 2) as u16, U, W)
                                 } else {
                                     if W {
-                                        // preindex has no wback
-                                        Operand::RegDerefPostindexOffset(Reg::from_u8(Rn), (imm8 << 2) as u16, U, false)
+                                        // postindex always has wback
+                                        Operand::RegDerefPostindexOffset(Reg::from_u8(Rn), (imm8 << 2) as u16, U, true)
                                     } else {
                                         Operand::RegDeref(Reg::from_u8(Rn))
                                     }
@@ -1823,9 +1823,10 @@ impl Decoder<ARMv7> for InstDecoder {
                                             if P {
                                                 Operand::RegDerefPreindexOffset(Reg::from_u8(Rn), imm, U, W)
                                             } else {
-                                                // either this is !P && W, so STRHT, and no wback,
-                                                // or this is !W, and no wback
-                                                Operand::RegDerefPostindexOffset(Reg::from_u8(Rn), imm, U, false)
+                                                // from
+                                                // https://developer.arm.com/documentation/111183/2025-09_ASL1/Base-Instructions/STRH--register---Store-Register-Halfword--register--?lang=en
+                                                // > let wback : boolean = (P == '0') || (W == '1');
+                                                Operand::RegDerefPostindexOffset(Reg::from_u8(Rn), imm, U, true)
                                             },
                                             Operand::Nothing,
                                             Operand::Nothing,
@@ -1844,9 +1845,10 @@ impl Decoder<ARMv7> for InstDecoder {
                                             if P {
                                                 Operand::RegDerefPreindexOffset(Reg::from_u8(Rn), imm, U, W)
                                             } else {
-                                                // either this is !P && W, so LDRHT, and no wback,
-                                                // or this is !W, and no wback
-                                                Operand::RegDerefPostindexOffset(Reg::from_u8(Rn), imm, U, false)
+                                                // from
+                                                // https://developer.arm.com/documentation/111183/2025-09_ASL1/Base-Instructions/LDRH--register---Load-Register-Halfword--register--?lang=en
+                                                // > let wback : boolean = (P == '0') || (W == '1');
+                                                Operand::RegDerefPostindexOffset(Reg::from_u8(Rn), imm, U, true)
                                             },
                                             Operand::Nothing,
                                             Operand::Nothing,
@@ -1948,8 +1950,8 @@ impl Decoder<ARMv7> for InstDecoder {
                                             if P {
                                                 Operand::RegDerefPreindexOffset(Reg::from_u8(Rn), imm, U, W)
                                             } else {
-                                                // either !P & W (invalid) or !W
-                                                Operand::RegDerefPostindexOffset(Reg::from_u8(Rn), imm, U, false)
+                                                // let wback : boolean = (P == '0') || (W == '1');
+                                                Operand::RegDerefPostindexOffset(Reg::from_u8(Rn), imm, U, true)
                                             },
                                             Operand::Nothing,
                                         ];
@@ -1974,8 +1976,8 @@ impl Decoder<ARMv7> for InstDecoder {
                                             if P {
                                                 Operand::RegDerefPreindexOffset(Reg::from_u8(Rn), imm, U, W)
                                             } else {
-                                                // either !P & W (ldrsbt) or !W
-                                                Operand::RegDerefPostindexOffset(Reg::from_u8(Rn), imm, U, false)
+                                                // if postindex then R(n) = offset_addr; end
+                                                Operand::RegDerefPostindexOffset(Reg::from_u8(Rn), imm, U, true)
                                             },
                                             Operand::Nothing,
                                             Operand::Nothing,
@@ -2071,8 +2073,7 @@ impl Decoder<ARMv7> for InstDecoder {
                                             if P {
                                                 Operand::RegDerefPreindexOffset(Reg::from_u8(Rn), imm, U, W)
                                             } else {
-                                                // either !P & W (invalid) or !W
-                                                Operand::RegDerefPostindexOffset(Reg::from_u8(Rn), imm, U, false)
+                                                Operand::RegDerefPostindexOffset(Reg::from_u8(Rn), imm, U, true)
                                             },
                                             Operand::Nothing,
                                         ];
@@ -2098,7 +2099,7 @@ impl Decoder<ARMv7> for InstDecoder {
                                                 Operand::RegDerefPreindexOffset(Reg::from_u8(Rn), imm, U, W)
                                             } else {
                                                 // either !P & W (ldrsht) or !W
-                                                Operand::RegDerefPostindexOffset(Reg::from_u8(Rn), imm, U, false)
+                                                Operand::RegDerefPostindexOffset(Reg::from_u8(Rn), imm, U, true)
                                             },
                                             Operand::Nothing,
                                             Operand::Nothing,
@@ -2729,7 +2730,7 @@ impl Decoder<ARMv7> for InstDecoder {
                     };
                     inst.operands = [
                         Operand::Reg(Reg::from_u8(Rt)),
-                        Operand::RegDerefPostindexOffset(Reg::from_u8(Rn), imm as u16, add, false),
+                        Operand::RegDerefPostindexOffset(Reg::from_u8(Rn), imm as u16, add, true),
                         Operand::Nothing,
                         Operand::Nothing,
                     ];
@@ -2763,7 +2764,10 @@ impl Decoder<ARMv7> for InstDecoder {
                                         if P {
                                             Operand::RegDerefPreindexOffset(Reg::from_u8(Rn), imm as u16, add, W)
                                         } else {
-                                            Operand::RegDerefPostindexOffset(Reg::from_u8(Rn), imm as u16, add, W)
+                                            // > wback == !P || W
+                                            //
+                                            // so always true here.
+                                            Operand::RegDerefPostindexOffset(Reg::from_u8(Rn), imm as u16, add, true)
                                         },
                                         Operand::Nothing,
                                         Operand::Nothing,
@@ -2781,7 +2785,10 @@ impl Decoder<ARMv7> for InstDecoder {
                                         if P {
                                             Operand::RegDerefPreindexOffset(Reg::from_u8(Rn), imm as u16, add, W)
                                         } else {
-                                            Operand::RegDerefPostindexOffset(Reg::from_u8(Rn), imm as u16, add, W)
+                                            // > wback == !P || W
+                                            //
+                                            // so always true here.
+                                            Operand::RegDerefPostindexOffset(Reg::from_u8(Rn), imm as u16, add, true)
                                         },
                                         Operand::Nothing,
                                         Operand::Nothing,
@@ -2799,7 +2806,10 @@ impl Decoder<ARMv7> for InstDecoder {
                         if P {
                             Operand::RegDerefPreindexOffset(Reg::from_u8(Rn), imm as u16, add, W)
                         } else {
-                            Operand::RegDerefPostindexOffset(Reg::from_u8(Rn), imm as u16, add, W)
+                            // > wback == !P || W
+                            //
+                            // so always true here.
+                            Operand::RegDerefPostindexOffset(Reg::from_u8(Rn), imm as u16, add, true)
                         },
                         Operand::Nothing,
                         Operand::Nothing,

--- a/src/armv7.rs
+++ b/src/armv7.rs
@@ -2947,10 +2947,10 @@ impl Decoder<ARMv7> for InstDecoder {
                     inst.opcode = Opcode::B;
 
                     // the + 2 is to compensate for an architecturally-defined initial offset
-                    let imm24 = ((((word & 0x00ff_ffff) + 2) << 8) as i32) >> 8;
+                    let imm24 = ((((word & 0x00ff_ffff)) << 8) as i32) >> 8;
 
                     inst.operands = [
-                        Operand::BranchOffset(imm24),
+                        Operand::BranchOffset(imm24 << 2),
                         Operand::Nothing,
                         Operand::Nothing,
                         Operand::Nothing,
@@ -2959,11 +2959,11 @@ impl Decoder<ARMv7> for InstDecoder {
                     // 11xxxx
 
                     // the + 2 is to compensate for an architecturally-defined initial offset
-                    let imm24 = ((((word & 0x00ff_ffff) + 2) << 8) as i32) >> 8;
+                    let imm24 = ((((word & 0x00ff_ffff)) << 8) as i32) >> 8;
 
                     inst.opcode = Opcode::BL;
                     inst.operands = [
-                        Operand::BranchOffset(imm24),
+                        Operand::BranchOffset(imm24 << 2),
                         Operand::Nothing,
                         Operand::Nothing,
                         Operand::Nothing,

--- a/src/armv7.rs
+++ b/src/armv7.rs
@@ -111,11 +111,11 @@ pub enum Opcode {
     STC2(u8),
     STC2L(u8),
     MCRR2(u8, u8),
-    MCR2(u8, u8, u8),
+    MCR(u8, u8, u8, bool),
     MRRC2(u8, u8),
     MCRR(u8, u8),
     MRRC(u8, u8),
-    MRC2(u8, u8, u8),
+    MRC(u8, u8, u8, bool),
     CDP2(u8, u8, u8),
     SRS(bool, bool),
     RFE(bool, bool),
@@ -1487,9 +1487,9 @@ impl Decoder<ARMv7> for InstDecoder {
                             // MCR2/MRC2, page A8-477/A8-493
                             let opc1 = (word >> 21) as u8 & 0b111;
                             if (word >> 20) & 1 == 0 {
-                                inst.opcode = Opcode::MCR2(coproc, opc1, opc2);
+                                inst.opcode = Opcode::MCR(coproc, opc1, opc2, true);
                             } else {
-                                inst.opcode = Opcode::MRC2(coproc, opc1, opc2);
+                                inst.opcode = Opcode::MRC(coproc, opc1, opc2, true);
                             }
                             inst.operands = [
                                 Operand::Reg(Reg::from_u8(Rt)),

--- a/src/armv7.rs
+++ b/src/armv7.rs
@@ -2977,12 +2977,38 @@ impl Decoder<ARMv7> for InstDecoder {
                     ];
                 }
             },
-            0b110 | 0b111 => {
+            0b110 => {
                 // coprocessor instructions and supervisor call
                 // page A5-213
                 // low bit of 0b110 or 0b111 corresponds to high bit of op1
                 return Err(DecodeError::Incomplete);
             },
+            0b111 => {
+                let op1 = (word >> 20) & 0b111111;
+                // MCR/MRC, page A8-493
+                if ((op1 >> 5) & 1) == 1 && ((op1 >> 4) & 1) == 0 {
+                    let CRm = word as u8 & 0b1111;
+                    let opc2 = (word >> 5) as u8 & 0b111;
+                    let coproc = (word >> 8) as u8 & 0b1111;
+                    let Rt = (word >> 12) as u8 & 0b1111;
+                    let CRn = (word >> 16) as u8 & 0b1111;
+
+                    let opc1 = (word >> 21) as u8 & 0b111;
+                    if (word >> 20) & 1 == 0 {
+                        inst.opcode = Opcode::MCR(coproc, opc1, opc2, false);
+                    } else {
+                        inst.opcode = Opcode::MRC(coproc, opc1, opc2, false);
+                    }
+                    inst.operands = [
+                        Operand::Reg(Reg::from_u8(Rt)),
+                        Operand::CReg(CReg::from_u8(CRn)),
+                        Operand::CReg(CReg::from_u8(CRm)),
+                        Operand::Nothing,
+                    ];
+                } else {
+                    return Err(DecodeError::Incomplete);
+                }
+            }
             _ => { unreachable!("opc category is three bits"); }
         }
         Ok(())

--- a/src/armv7.rs
+++ b/src/armv7.rs
@@ -1154,6 +1154,13 @@ impl InstDecoder {
         Self::default().with_thumb_mode(true)
     }
 
+    /// control whether bitfields the manual suggests be zeroed, must be. in practice these bits
+    /// may have no architectural effect, and are ignored in decoding if allowed.
+    pub fn with_nonconforming(mut self, allow: bool) -> Self {
+        self.should_is_must = !allow;
+        self
+    }
+
     /// create an `InstDecoder` that supports only instructions through to `ARMv4`.
     pub fn armv4() -> Self {
         Self {
@@ -1909,7 +1916,7 @@ impl Decoder<ARMv7> for InstDecoder {
                                             inst.opcode = Opcode::LDRSB;
                                         }
                                         if self.should_is_must {
-                                            if (word >> 8) & 0b1111 == 0 {
+                                            if (word >> 8) & 0b1111 != 0 {
                                                 return Err(DecodeError::Nonconforming);
                                             }
                                         }
@@ -1997,7 +2004,7 @@ impl Decoder<ARMv7> for InstDecoder {
                                             inst.opcode = Opcode::STRD;
                                         }
                                         if self.should_is_must {
-                                            if (word >> 8) & 0b1111 == 0 {
+                                            if (word >> 8) & 0b1111 != 0 {
                                                 return Err(DecodeError::Nonconforming);
                                             }
                                         }

--- a/src/armv7/display.rs
+++ b/src/armv7/display.rs
@@ -532,7 +532,12 @@ pub(crate) fn visit_inst<T: DisplaySink>(instr: &Instruction, out: &mut T) -> fm
             out.span_end_opcode();
             out.write_fixed_size(" p")?;
             // coproc is a 3-bit field
-            out.write_char((coproc + 0x30) as char)?;
+            if coproc < 10 {
+                out.write_char((coproc + 0x30) as char)?;
+            } else {
+                out.write_char('1')?;
+                out.write_char((coproc + 0x26) as char)?;
+            }
 
             out.write_fixed_size(", ")?;
             // opc1 is a 3-bit field

--- a/src/armv7/display.rs
+++ b/src/armv7/display.rs
@@ -522,8 +522,8 @@ pub(crate) fn visit_inst<T: DisplaySink>(instr: &Instruction, out: &mut T) -> fm
 
             return Ok(());
         }
-        Opcode::MRC2(coproc, opc1, opc2) |
-        Opcode::MCR2(coproc, opc1, opc2) |
+        Opcode::MRC(coproc, opc1, opc2, _) |
+        Opcode::MCR(coproc, opc1, opc2, _) |
         Opcode::CDP2(coproc, opc1, opc2) => {
             out.span_start_opcode();
             unsafe {
@@ -918,9 +918,9 @@ impl <T: fmt::Write, Y: YaxColors> Colorize<T, Y> for ConditionedOpcode {
             Opcode::STC2(_) |
             Opcode::STC2L(_) |
             Opcode::MCRR2(_, _) |
-            Opcode::MCR2(_, _, _) |
+            Opcode::MCR(_, _, _, _) |
             Opcode::MRRC2(_, _) |
-            Opcode::MRC2(_, _, _) |
+            Opcode::MRC(_, _, _, _) |
             Opcode::MCRR(_, _) |
             Opcode::MRRC(_, _) |
             Opcode::CDP2(_, _, _) => { write!(out, "{}", colors.platform_op(self)) },
@@ -957,9 +957,11 @@ impl Opcode {
             Opcode::STC2(_) => { "stc2" },
             Opcode::STC2L(_) => { "stc2l" },
             Opcode::MCRR2(_, _) => { "mcrr2" },
-            Opcode::MCR2(_, _, _) => { "mcr2" },
+            Opcode::MCR(_, _, _, false) => { "mcr" },
+            Opcode::MCR(_, _, _, true) => { "mcr2" },
             Opcode::MRRC2(_, _) => { "mrrc2" },
-            Opcode::MRC2(_, _, _) => { "mrc2" },
+            Opcode::MRC(_, _, _, false) => { "mrc" },
+            Opcode::MRC(_, _, _, true) => { "mrc2" },
             Opcode::MCRR(_, _) => { "mcrr" },
             Opcode::MRRC(_, _) => { "mrrc" },
             Opcode::CDP2(_, _, _) => { "cdp2" },

--- a/src/armv7/display.rs
+++ b/src/armv7/display.rs
@@ -375,7 +375,7 @@ pub(crate) fn visit_inst<T: DisplaySink>(instr: &Instruction, out: &mut T) -> fm
         Opcode::LDR => {
             match instr.operands {
                 // TODO: should this be PostindexOffset?
-                [Operand::Reg(Rt), Operand::RegDerefPostindexOffset(Reg { bits: 13 }, 4, true, false), Operand::Nothing, Operand::Nothing] => {
+                [Operand::Reg(Rt), Operand::RegDerefPostindexOffset(Reg { bits: 13 }, 4, true, true), Operand::Nothing, Operand::Nothing] => {
                     out.span_start_opcode();
                     instr.write_conditioned_opcode(&Opcode::POP, out)?;
                     out.span_end_opcode();

--- a/src/armv7/display.rs
+++ b/src/armv7/display.rs
@@ -24,6 +24,15 @@ impl<T: DisplaySink> DisplaySinkExt for T {
     }
 }
 
+#[cfg(feature="fmt")]
+impl Reg {
+    /// translate this register operand into a `str` name.
+    pub fn name(&self) -> &'static str {
+        REG_NAMES.get(self.bits as usize)
+            .unwrap_or_else(|| unsafe { core::hint::unreachable_unchecked() })
+    }
+}
+
 /// an instruction and display settings to configure [`Display](fmt::Display)-formatting of the
 /// instruction.
 ///
@@ -302,7 +311,7 @@ impl<T: DisplaySink> crate::armv7::OperandVisitor for DisplayingOperandVisitor<'
         if offset >= 0 {
             self.f.write_char('+')?;
         }
-        self.f.write_prefixed_i32(offset << 2)
+        self.f.write_prefixed_i32(offset)
     }
 
     fn visit_blx_offset(&mut self, offset: i32) -> Result<Self::Ok, Self::Error> {
@@ -310,7 +319,7 @@ impl<T: DisplaySink> crate::armv7::OperandVisitor for DisplayingOperandVisitor<'
         if offset >= 0 {
             self.f.write_char('+')?;
         }
-        self.f.write_prefixed_i32(offset << 1)
+        self.f.write_prefixed_i32(offset)
     }
 
     fn visit_coprocessor_option(&mut self, nr: u8) -> Result<Self::Ok, Self::Error> {

--- a/src/armv7/display.rs
+++ b/src/armv7/display.rs
@@ -1014,14 +1014,12 @@ impl Opcode {
             Opcode::STREX => { "strex" },
             Opcode::LDM(false, false, _, _) => { "ldmda" },
             Opcode::LDM(false, true, _, _) => { "ldmdb" },
-            // TODO: seems like these are backwards
             Opcode::LDM(true, false, _, _) => { "ldm" },
-            Opcode::LDM(true, true, _, _) => { "ldmia" },
+            Opcode::LDM(true, true, _, _) => { "ldmib" },
             Opcode::STM(false, false, _, _) => { "stmda" },
             Opcode::STM(false, true, _, _) => { "stmdb" },
-            // TODO: seems like these are backwards
             Opcode::STM(true, false, _, _) => { "stm" },
-            Opcode::STM(true, true, _, _) => { "stmia" },
+            Opcode::STM(true, true, _, _) => { "stmib" },
             Opcode::LDR => { "ldr" },
             Opcode::STR => { "str" },
             Opcode::LDRH => { "ldrh" },

--- a/src/armv7/thumb.rs
+++ b/src/armv7/thumb.rs
@@ -4154,7 +4154,7 @@ pub fn decode_into<T: Reader<<ARMv7 as Arch>::Address, <ARMv7 as Arch>::Word>>(d
             // `STM (STMIA, STMEA)` on page `A8-665` -- v4T
             let rn = instr2[8..11].load::<u8>();
             let reglist = instr2[0..8].load::<u16>();
-            inst.opcode = Opcode::STM(true, true, false, true); // stmia, no wback, yes usermode
+            inst.opcode = Opcode::STM(true, false, false, true); // stmia, no wback, yes usermode
             inst.operands = [
                 Operand::RegWBack(Reg::from_u8(rn), true), // always wback
                 Operand::RegList(reglist as u16),

--- a/src/armv7/thumb.rs
+++ b/src/armv7/thumb.rs
@@ -1506,7 +1506,7 @@ pub fn decode_into<T: Reader<<ARMv7 as Arch>::Address, <ARMv7 as Arch>::Word>>(d
                         inst.condition = ConditionCode::build(((instr >> 6) & 0b1111) as u8);
                         inst.opcode = Opcode::B;
                         inst.operands = [
-                            Operand::BranchThumbOffset(imm),
+                            Operand::BranchThumbOffset(imm << 1),
                             Operand::Nothing,
                             Operand::Nothing,
                             Operand::Nothing,
@@ -1973,7 +1973,7 @@ pub fn decode_into<T: Reader<<ARMv7 as Arch>::Address, <ARMv7 as Arch>::Word>>(d
                         ((s as i32) << 23);
                     let imm = (imm << 8) >> 8;
                     inst.operands = [
-                        Operand::BranchThumbOffset(imm),
+                        Operand::BranchThumbOffset(imm << 1),
                         Operand::Nothing,
                         Operand::Nothing,
                         Operand::Nothing,
@@ -3848,7 +3848,7 @@ pub fn decode_into<T: Reader<<ARMv7 as Arch>::Address, <ARMv7 as Arch>::Word>>(d
                 };
                 inst.operands = [
                     Operand::Reg(Reg::from_u8(rn)),
-                    Operand::BranchThumbOffset(imm as i32 + 1),
+                    Operand::BranchThumbOffset((imm as i32) << 1),
                     Operand::Nothing,
                     Operand::Nothing,
                 ];
@@ -3914,7 +3914,7 @@ pub fn decode_into<T: Reader<<ARMv7 as Arch>::Address, <ARMv7 as Arch>::Word>>(d
                 };
                 inst.operands = [
                     Operand::Reg(Reg::from_u8(rn)),
-                    Operand::BranchThumbOffset(imm as i32 + 1),
+                    Operand::BranchThumbOffset((imm as i32) << 1),
                     Operand::Nothing,
                     Operand::Nothing,
                 ];
@@ -3975,7 +3975,7 @@ pub fn decode_into<T: Reader<<ARMv7 as Arch>::Address, <ARMv7 as Arch>::Word>>(d
                 };
                 inst.operands = [
                     Operand::Reg(Reg::from_u8(rn)),
-                    Operand::BranchThumbOffset(imm as i32 + 1),
+                    Operand::BranchThumbOffset((imm as i32) << 1),
                     Operand::Nothing,
                     Operand::Nothing,
                 ];
@@ -4032,7 +4032,7 @@ pub fn decode_into<T: Reader<<ARMv7 as Arch>::Address, <ARMv7 as Arch>::Word>>(d
                 };
                 inst.operands = [
                     Operand::Reg(Reg::from_u8(rn)),
-                    Operand::BranchThumbOffset(imm as i32 + 1),
+                    Operand::BranchThumbOffset((imm as i32) << 1),
                     Operand::Nothing,
                     Operand::Nothing,
                 ];
@@ -4183,7 +4183,7 @@ pub fn decode_into<T: Reader<<ARMv7 as Arch>::Address, <ARMv7 as Arch>::Word>>(d
                 let imm = instr2[0..8].load::<u8>() as i8 as i32;
                 inst.condition = ConditionCode::build(opcode);
                 inst.operands = [
-                    Operand::BranchThumbOffset(imm + 1),
+                    Operand::BranchThumbOffset(imm << 1),
                     Operand::Nothing,
                     Operand::Nothing,
                     Operand::Nothing,
@@ -4218,7 +4218,7 @@ pub fn decode_into<T: Reader<<ARMv7 as Arch>::Address, <ARMv7 as Arch>::Word>>(d
             let imm = instr2[0..11].load::<u32>();
             let imm = ((imm as i32) << 21) >> 21;
             inst.operands = [
-                Operand::BranchThumbOffset(imm),
+                Operand::BranchThumbOffset(imm << 1),
                 Operand::Nothing,
                 Operand::Nothing,
                 Operand::Nothing,

--- a/tests/armv7/mod.rs
+++ b/tests/armv7/mod.rs
@@ -394,7 +394,7 @@ fn test_decode_pop() {
             opcode: Opcode::LDR,
             operands: [
                 Operand::Reg(Reg::from_u8(1)),
-                Operand::RegDerefPostindexOffset(Reg::from_u8(13), 0x4, true, false),
+                Operand::RegDerefPostindexOffset(Reg::from_u8(13), 0x4, true, true),
                 Operand::Nothing,
                 Operand::Nothing,
             ],

--- a/tests/armv7/mod.rs
+++ b/tests/armv7/mod.rs
@@ -90,6 +90,11 @@ fn test_nonconformant(data: [u8; 4]) {
         result == Err(DecodeError::Nonconforming),
         "got bad result: {:?} from {:#x?}", result, data
     );
+    let mut reader = yaxpeax_arch::U8Reader::new(&data[..]);
+    let result2 = InstDecoder::default()
+        .with_nonconforming(true)
+        .decode(&mut reader);
+    result2.expect("ok");
 }
 
 fn test_display(data: [u8; 4], expected: &'static str) {
@@ -228,14 +233,15 @@ fn test_decode_str_ldr() {
     test_all([0xbb, 0x38, 0xb5, 0xe1], "ldrh r3, [r5, fp]!");
     test_all([0xbb, 0x38, 0xe5, 0xe1], "strh r3, [r5, 0x8b]!");
     test_all([0xbb, 0x38, 0xf5, 0xe1], "ldrh r3, [r5, 0x8b]!");
+    test_all([0xd6, 0x00, 0x95, 0xe1], "ldrsb r0, [r5, r6]");
     test_armv5([0xdb, 0x48, 0xa6, 0xe1], "ldrd r4, r5, [r6, fp]!");
     test_invalid([0xdb, 0x38, 0xa5, 0xe1]);
-    test_all([0xdb, 0x38, 0xb5, 0xe1], "ldrsb r3, [r5, fp]!");
+    test_nonconformant([0xdb, 0x38, 0xb5, 0xe1]); // , "ldrsb r3, [r5, fp]!");
     test_armv5([0xdb, 0x48, 0xe6, 0xe1], "ldrd r4, r5, [r6, 0x8b]!");
     test_invalid([0xdb, 0x38, 0xe5, 0xe1]);
     test_all([0xdb, 0x38, 0xf5, 0xe1], "ldrsb r3, [r5, 0x8b]!");
     test_invalid([0xfb, 0x38, 0xa5, 0xe1]);
-    test_all([0xfb, 0x48, 0xa6, 0xe1], "strd r4, r5, [r6, fp]!");
+    test_nonconformant([0xfb, 0x48, 0xa6, 0xe1]); //, "strd r4, r5, [r6, fp]!");
     test_all([0xfb, 0x30, 0xb5, 0xe1], "ldrsh r3, [r5, fp]!");
     test_invalid([0xfb, 0x30, 0xe5, 0xe1]);
     test_all([0xfb, 0x48, 0xe6, 0xe1], "strd r4, r5, [r6, 0x8b]!");

--- a/tests/armv7/mod.rs
+++ b/tests/armv7/mod.rs
@@ -112,6 +112,10 @@ fn test_unpredictable_instructions() {
 
 #[test]
 fn test_decode_str_ldr() {
+    test_display(
+        [0xfc, 0xb0, 0x98, 0xe1],
+        "ldrsh fp, [r8, ip]"
+    );
     test_decode(
         [0x24, 0xc0, 0x9f, 0xe5],
         Instruction {
@@ -232,8 +236,8 @@ fn test_decode_str_ldr() {
     test_all([0xdb, 0x38, 0xf5, 0xe1], "ldrsb r3, [r5, 0x8b]!");
     test_invalid([0xfb, 0x38, 0xa5, 0xe1]);
     test_all([0xfb, 0x48, 0xa6, 0xe1], "strd r4, r5, [r6, fp]!");
-    test_all([0xfb, 0x38, 0xb5, 0xe1], "ldrsh r3, [r5, fp]!");
-    test_invalid([0xfb, 0x38, 0xe5, 0xe1]);
+    test_all([0xfb, 0x30, 0xb5, 0xe1], "ldrsh r3, [r5, fp]!");
+    test_invalid([0xfb, 0x30, 0xe5, 0xe1]);
     test_all([0xfb, 0x48, 0xe6, 0xe1], "strd r4, r5, [r6, 0x8b]!");
     test_all([0xfb, 0x38, 0xf5, 0xe1], "ldrsh r3, [r5, 0x8b]!");
     test_all([0xfb, 0x38, 0xff, 0xe1], "ldrsh r3, [pc, 0x8b]!");
@@ -257,6 +261,10 @@ fn test_shift_rotate() {
     test_display(
         [0x5b, 0x5a, 0xa0, 0xe1],
         "mov r5, fp, asr r10"
+    );
+    test_display(
+        [0x88, 0x80, 0xa0, 0xe1],
+        "lsl r8, r8, 1"
     );
 }
 
@@ -557,6 +565,19 @@ fn test_decode_arithmetic() {
             thumb: false,
             wide: false,
         }
+    );
+
+    test_display(
+        [0xaa, 0xa4, 0x81, 0xe0],
+        "add r10, r1, r10, lsr 9"
+    );
+    test_display(
+        [0x0f, 0x40, 0x0a, 0xe2],
+        "andeq r1, r0, r8, lsl sp",
+    );
+    test_display(
+        [0x0f, 0x40, 0x0a, 0xe2],
+        "and r4, r10",
     );
 }
 

--- a/tests/armv7/mod.rs
+++ b/tests/armv7/mod.rs
@@ -241,6 +241,26 @@ fn test_decode_str_ldr() {
 }
 
 #[test]
+fn test_shift_rotate() {
+    test_display(
+        [0x82, 0xa5, 0xa0, 0xe1],
+        // ideally: "lsl sl, r2, 0xb"
+        // but will tolerate:
+        "mov r10, r2, lsl 11"
+    );
+    test_display(
+        [0xa2, 0x2c, 0xb0, 0xe1],
+        // ideally: "lsrs r2, r2, 0x19"
+        // but will tolerate:
+        "movs r2, r2, lsr 25"
+    );
+    test_display(
+        [0x5b, 0x5a, 0xa0, 0xe1],
+        "mov r5, fp, asr r10"
+    );
+}
+
+#[test]
 fn test_synchronization() {
     test_display(
         [0x94, 0x8f, 0x8a, 0xe1],
@@ -519,7 +539,7 @@ fn test_decode_arithmetic() {
         Instruction {
             condition: ConditionCode::AL,
             opcode: Opcode::MOV,
-            operands: [Operand::Reg(Reg::from_u8(3)), Operand::Reg(Reg::from_u8(0)), Operand::RegShift(RegShift::from_raw(0x143)), Operand::Nothing],
+            operands: [Operand::Reg(Reg::from_u8(3)), Operand::RegShift(RegShift::from_raw(0x143)), Operand::Nothing, Operand::Nothing],
             s: false,
             thumb_w: false,
             thumb: false,

--- a/tests/armv7/thumb.rs
+++ b/tests/armv7/thumb.rs
@@ -3210,39 +3210,39 @@ fn test_decode_rev_cases() {
 fn test_decode_stm_16b_cases() {
     test_display(
         &[0x01, 0xc0],
-        "stmia r0!, {r0}"
+        "stm r0!, {r0}"
     );
     test_display(
         &[0x01, 0xc1],
-        "stmia r1!, {r0}"
+        "stm r1!, {r0}"
     );
     test_display(
         &[0x01, 0xc2],
-        "stmia r2!, {r0}"
+        "stm r2!, {r0}"
     );
     test_display(
         &[0x01, 0xc3],
-        "stmia r3!, {r0}"
+        "stm r3!, {r0}"
     );
     test_display(
         &[0x01, 0xc4],
-        "stmia r4!, {r0}"
+        "stm r4!, {r0}"
     );
     test_display(
         &[0x01, 0xc5],
-        "stmia r5!, {r0}"
+        "stm r5!, {r0}"
     );
     test_display(
         &[0x01, 0xc6],
-        "stmia r6!, {r0}"
+        "stm r6!, {r0}"
     );
     test_display(
         &[0x01, 0xc7],
-        "stmia r7!, {r0}"
+        "stm r7!, {r0}"
     );
     test_display(
         &[0xff, 0xc3],
-        "stmia r3!, {r0, r1, r2, r3, r4, r5, r6, r7}"
+        "stm r3!, {r0, r1, r2, r3, r4, r5, r6, r7}"
     );
 }
 #[test]


### PR DESCRIPTION
MCR/MRC are basically MCR2/MRC2 but with cond set to 0b1111.

This is sort of temporary solution while other coprocessor instructions are missing, but I haven't found others in real binaries yet.

```
ROM:02007570                 MRC             p15, 0, R12,c1,c0, 0
...
ROM:0200757C                 MCR             p15, 0, R12,c1,c0, 0
```
can be properly decoded with yaxpeax now:
```
0x70: mrc p15, 0, ip, c1, c0, 0
...
0x7c: mcr p15, 0, ip, c1, c0, 0
```