### PR TITLE
alias PUSH/POP to STM/LDM/STR/LDR

### DIFF
--- a/src/armv7.rs
+++ b/src/armv7.rs
@@ -2856,21 +2856,42 @@ impl Decoder<ARMv7> for InstDecoder {
                 // page A5-212
                 let op = (word >> 20) & 0x3f;
                 if op < 0b100000 {
+                    let load = (op & 1) != 0;
                     let wback = (op & 0b000010) != 0;
                     let add = (op & 0b001000) != 0;
                     let pre = (op & 0b010000) != 0;
                     let usermode = (op & 0b000100) != 0;
-                    inst.opcode = if (op & 1) == 0 {
-                        Opcode::STM(add, pre, false, usermode)
+                    let reg = ((word >> 16) & 0xf) as u8;
+                    let regs = (word & 0xffff) as u16;
+
+                    let is_at_least_2_regs = regs.count_ones() >= 2;
+                    let is_sp = reg == 13;
+                    if is_at_least_2_regs && is_sp && wback {
+                        inst.opcode = if load {
+                            Opcode::POP
+                        } else {
+                            Opcode::PUSH
+                        };
+
+                        inst.operands = [
+                            Operand::RegList(regs),
+                            Operand::Nothing,
+                            Operand::Nothing,
+                            Operand::Nothing,
+                        ];
                     } else {
-                        Opcode::LDM(add, pre, false, usermode)
-                    };
-                    inst.operands = [
-                        Operand::RegWBack(Reg::from_u8(((word >> 16) & 0xf) as u8), wback),
-                        Operand::RegList((word & 0xffff) as u16),
-                        Operand::Nothing,
-                        Operand::Nothing,
-                    ];
+                        inst.opcode = if load {
+                            Opcode::LDM(add, pre, false, usermode)
+                        } else {
+                            Opcode::STM(add, pre, false, usermode)
+                        };
+                        inst.operands = [
+                            Operand::RegWBack(Reg::from_u8(((word >> 16) & 0xf) as u8), wback),
+                            Operand::RegList((word & 0xffff) as u16),
+                            Operand::Nothing,
+                            Operand::Nothing,
+                        ];
+                    }
                 } else if op < 0b110000 {
                     // 10xxxx
                     inst.opcode = Opcode::B;

--- a/src/armv7.rs
+++ b/src/armv7.rs
@@ -2721,23 +2721,50 @@ impl Decoder<ARMv7> for InstDecoder {
                         }
                     } else {
                         match op {
-                            0b000 => Opcode::STR,
-                            0b001 => {
-                                if Rn == 0b1111 {
+                            0b000 => {
+                                // PUSH Rt
+                                if Rn == 0b1101 {
                                     inst.operands = [
                                         Operand::Reg(Reg::from_u8(Rt)),
-                                        if P {
-                                            Operand::RegDerefPreindexOffset(Reg::from_u8(Rn), imm as u16, add, W)
-                                        } else {
-                                            Operand::RegDerefPostindexOffset(Reg::from_u8(Rn), imm as u16, add, W)
-                                        },
+                                        Operand::Nothing,
                                         Operand::Nothing,
                                         Operand::Nothing,
                                     ];
-                                    inst.opcode = Opcode::LDR;
+                                    inst.opcode = Opcode::PUSH;
                                     return Ok(());
                                 }
-                                Opcode::LDR
+                                Opcode::STR
+                            },
+                            0b001 => {
+                                match Rn {
+                                    // POP Rt
+                                    0b1101 => {
+                                        inst.operands = [
+                                            Operand::Reg(Reg::from_u8(Rt)),
+                                            Operand::Nothing,
+                                            Operand::Nothing,
+                                            Operand::Nothing,
+                                        ];
+                                        inst.opcode = Opcode::POP;
+                                        return Ok(());
+                                    },
+                                    // LDR Rt, [PC, #imm]
+                                    0b1111 => {
+                                        inst.operands = [
+                                            Operand::Reg(Reg::from_u8(Rt)),
+                                            if P {
+                                                Operand::RegDerefPreindexOffset(Reg::from_u8(Rn), imm as u16, add, W)
+                                            } else {
+                                                Operand::RegDerefPostindexOffset(Reg::from_u8(Rn), imm as u16, add, W)
+                                            },
+                                            Operand::Nothing,
+                                            Operand::Nothing,
+                                        ];
+                                        inst.opcode = Opcode::LDR;
+                                        return Ok(());
+                                    }
+                                    _ => Opcode::LDR
+                                }
                             },
                             0b100 => Opcode::STRB,
                             0b101 => {

--- a/tests/armv7/mod.rs
+++ b/tests/armv7/mod.rs
@@ -150,10 +150,10 @@ fn test_decode_str_ldr() {
         [0x04, 0x20, 0x2d, 0xe5],
         Instruction {
             condition: ConditionCode::AL,
-            opcode: Opcode::STR,
+            opcode: Opcode::PUSH,
             operands: [
                 Operand::Reg(Reg::from_u8(2)),
-                Operand::RegDerefPreindexOffset(Reg::from_u8(13), 4, false, true),
+                Operand::Nothing,
                 Operand::Nothing,
                 Operand::Nothing,
             ],
@@ -167,10 +167,10 @@ fn test_decode_str_ldr() {
         [0x04, 0x00, 0x2d, 0xe5],
         Instruction {
             condition: ConditionCode::AL,
-            opcode: Opcode::STR,
+            opcode: Opcode::PUSH,
             operands: [
                 Operand::Reg(Reg::from_u8(0)),
-                Operand::RegDerefPreindexOffset(Reg::from_u8(13), 4, false, true),
+                Operand::Nothing,
                 Operand::Nothing,
                 Operand::Nothing,
             ],
@@ -371,10 +371,10 @@ fn test_decode_pop() {
         [0x04, 0x10, 0x9d, 0xe4],
         Instruction {
             condition: ConditionCode::AL,
-            opcode: Opcode::LDR,
+            opcode: Opcode::POP,
             operands: [
                 Operand::Reg(Reg::from_u8(1)),
-                Operand::RegDerefPostindexOffset(Reg::from_u8(13), 0x4, true, false),
+                Operand::Nothing,
                 Operand::Nothing,
                 Operand::Nothing,
             ],
@@ -386,16 +386,16 @@ fn test_decode_pop() {
     );
     test_display(
         [0x04, 0x10, 0x9d, 0xe4],
-        "pop {r1}"
+        "pop r1" // this is A2 encoding, so only one register can be POPed
     );
     test_decode(
         [0xf0, 0x40, 0x2d, 0xe9],
         Instruction {
             condition: ConditionCode::AL,
-            opcode: Opcode::STM(false, true, false, false),
+            opcode: Opcode::PUSH,
             operands: [
-                Operand::RegWBack(Reg::from_u8(13), true),
                 Operand::RegList(16624),
+                Operand::Nothing,
                 Operand::Nothing,
                 Operand::Nothing,
             ],
@@ -413,10 +413,10 @@ fn test_decode_pop() {
         [0xf0, 0x80, 0xbd, 0x18],
         Instruction {
             condition: ConditionCode::NE,
-            opcode: Opcode::LDM(true, false, false, false),
+            opcode: Opcode::POP,
             operands: [
-                Operand::RegWBack(Reg::from_u8(13), true),
                 Operand::RegList(33008),
+                Operand::Nothing,
                 Operand::Nothing,
                 Operand::Nothing,
             ],


### PR DESCRIPTION
even though PUSH/POP are pseudo-instructions, most disassemblers output them as PUSH/POP, as well as Thumb decoder does. it helps to distinguish between regular STR/LDR and PUSH/POP.

partially solves #23

note that A2 encoding allows to operate only on one register, so it has `Operand::Reg` and not `Operand::RegList`.