### PR TITLE
fix blx for far jumps

### DIFF
--- a/src/armv7.rs
+++ b/src/armv7.rs
@@ -1333,12 +1333,11 @@ impl Decoder<ARMv7> for InstDecoder {
                     }
                     0b01 => {
                         inst.opcode = Opcode::BLX;
-                        let operand = ((word & 0xffffff) as i32) << 8 >> 7;
+                        let imm24 = ((word & 0xffffff) as i32) << 8 >> 7;
+                        let h = (word >> 24) & 1;
                         inst.operands = [
                             Operand::BranchThumbOffset(
-                                operand | (
-                                    ((word >> 24) & 0b1) as i32
-                                )
+                                (imm24 << 1) | (h << 1) as i32
                             ),
                             Operand::Nothing,
                             Operand::Nothing,


### PR DESCRIPTION
code: `2B 5D 00 FA`
expected: `blx #0x174b4`
result: `blx $+0xba56`

for proper blx decoding with far jump the imm24 should be shifted by 1 and 24th bit should be applied too.

edit: oops looked at the wrong offset, sorry, force pushed with proper fix