### PR TITLE
Add armv7::InstDecoder::in_thumb_mode() method

### DIFF
--- a/src/armv7.rs
+++ b/src/armv7.rs
@@ -1129,6 +1129,11 @@ impl InstDecoder {
         self
     }
 
+    /// Returns whether the decoder is currently set to decode in THUMB mode
+    pub fn in_thumb_mode(&self) -> bool {
+        self.thumb
+    }
+
     /// initialize a new `arm` `InstDecoder` with default ("everything") support, but in `thumb`
     /// mode.
     pub fn default_thumb() -> Self {


### PR DESCRIPTION
We can currently set the decoder to THUMB mode using the `.set_thumb_mode()` method. But we currently can't actually check whether the decoder is currently in THUMB mode. This PR aims to rectify that by adding a simple getter method.