### PR TITLE
Check all of the appropriate bits when parsing op1 for CDP2/MCR2/MRC2

### DIFF
--- a/src/armv7.rs
+++ b/src/armv7.rs
@@ -1446,6 +1446,17 @@ impl Decoder<ARMv7> for InstDecoder {
                         }
                     }
                     0b11 => {
+                        // We know the instruction looks like this...
+                        // |1 1 1 1|1 1 1|x x x x|x|x x x x|x x x x|x x x x x|x x|x|x x x x|
+                        //                ^ We need to check that this bit is zero, if any of the
+                        //                  instructions decoded in this block are to match
+                        //                  correctly.
+                        // See A5-214 for the table that shows the required forms for these
+                        // instructions.
+                        if (op1 >> 4) & 1 != 0 {
+                            return Err(DecodeError::InvalidOpcode);
+                        }
+
                         // operands are shared between cdp2 and mcr2/mrc2, but Rt is repurposed as
                         // CRd
                         let CRm = word as u8 & 0b1111;

--- a/tests/armv7/mod.rs
+++ b/tests/armv7/mod.rs
@@ -696,6 +696,15 @@ fn test_decode_mul() {
     );
 }
 
+#[test]
+fn test_decode_mrc2() {
+    // Previous versions of this crate would incorrectly decode this as
+    // "mrc2 p<, 7, lr, c15, c12, 5", which is inaccurate. (The LSB of the last byte being set
+    // makes it an invalid instruction.)
+    test_invalid([0xbc, 0xec, 0xff, 0xff]);
+    test_armv6([0xbc, 0xec, 0xff, 0xfe], "mrc2 p12, 7, lr, c15, c12, 5");
+}
+
 static INSTRUCTION_BYTES: [u8; 4 * 60] = [
         0x24, 0xc0, 0x9f, 0xe5,
         0x00, 0xb0, 0xa0, 0xe3,


### PR DESCRIPTION
The ARM reference manual referenced in the ARMv7 decoder source says that the `op1` field in a CDP2/MCR2/MRC2 instruction has to have it's 4 most-significant bits set to `0b1110` but previously only the 3 most-significant bits were checked. This means that invalid instrucitions would incorrectly be decoded as CDP2/MCR2/MRC2 instrctions. This issue was found by comparing the output of `yaxpeax-arm` with that of `capstone`.