### PR TITLE
Fix the handling of arithmetic register shifts with zero immediates

### DIFF
--- a/src/armv7.rs
+++ b/src/armv7.rs
@@ -389,7 +389,17 @@ pub struct RegImmShift {
 impl RegImmShift {
     /// the immediate this register is shifted by.
     pub fn imm(&self) -> u8 {
-        (self.data >> 7) as u8 & 0b11111
+        let raw = (self.data >> 7) as u8 & 0b11111;
+        match self.stype() {
+            // These two variants treat the immediate being all zeros as if the immediate was 32.
+            // See A8-289 for details.
+            ShiftStyle::LSR
+            |ShiftStyle::ASR if raw == 0 => 32,
+            ShiftStyle::LSL
+            |ShiftStyle::LSR
+            |ShiftStyle::ASR
+            |ShiftStyle::ROR => raw,
+        }
     }
     /// the way in which this register is shifted.
     pub fn stype(&self) -> ShiftStyle {

--- a/tests/armv7/mod.rs
+++ b/tests/armv7/mod.rs
@@ -696,6 +696,15 @@ fn test_decode_mul() {
     );
 }
 
+#[test]
+fn test_register_shift_with_zero_immediate() {
+    // Previous versions of this crate would incorrectly decode this as
+    // "eoreq r0, r0, r1, lsr 0", which is wrong. When an LSR or ASR shift has an encoded immediate
+    // of zero, it actually means that the applied shift is 32.
+    test_armv6([0x21, 0x00, 0x20, 0x00], "eoreq r0, r0, r1, lsr 32");
+    test_armv6([0x41, 0x00, 0x20, 0x00], "eoreq r0, r0, r1, asr 32");
+}
+
 static INSTRUCTION_BYTES: [u8; 4 * 60] = [
         0x24, 0xc0, 0x9f, 0xe5,
         0x00, 0xb0, 0xa0, 0xe3,


### PR DESCRIPTION
The ARM reference used by the ARMv7 decoder mentions that for arithmetic shift operations, an immdiate of zero actually means to shift by 32 bits. While this is a relatively useless operation, there is a difference in semantics between the two, and this PR tries to fix up the immediate before returning it to the user in such cases.