### PR TITLE
fix several thumb2 decode bugs

### DIFF
--- a/src/armv7/thumb.rs
+++ b/src/armv7/thumb.rs
@@ -357,15 +357,14 @@ pub fn decode_into<T: Reader<<ARMv7 as Arch>::Address, <ARMv7 as Arch>::Word>>(d
                                         // TODO: should_is_must()
                                         // rt == 0b1111
                                         // rd == 0b0000
-                                        inst.opcode = Opcode::TBB;
+                                        inst.opcode = Opcode::TBH;
                                         inst.operands = [
                                             Operand::RegDerefPreindexRegShift(
                                                 Reg::from_u8(rn),
                                                 // want `<Rm>, LSL #1`, construct a raw shift
-                                                // ourselves
+                                                // ourselves. bit 4 clear selects `RegImm`.
                                                 RegShift::from_raw(
-                                                    0b10000 |        // `RegImm`
-                                                    rd as u16 |            // reg == rd
+                                                    rd as u16 |     // reg == rm
                                                     (0b00 << 5) |   // LSL
                                                     (1 << 7)        // shift == #1
                                                 ),

--- a/src/armv7/thumb.rs
+++ b/src/armv7/thumb.rs
@@ -2856,7 +2856,7 @@ pub fn decode_into<T: Reader<<ARMv7 as Arch>::Address, <ARMv7 as Arch>::Word>>(d
                                     Opcode::LSR,
                                     Opcode::ASR,
                                     Opcode::ROR,
-                                ][op2[1..3].load::<usize>()];
+                                ][op1[1..3].load::<usize>()];
                                 let rd = lower2[8..12].load::<u8>();
                                 let rm = lower2[0..4].load::<u8>();
                                 inst.opcode = op;
@@ -2884,14 +2884,18 @@ pub fn decode_into<T: Reader<<ARMv7 as Arch>::Address, <ARMv7 as Arch>::Word>>(d
                                     ][op1];
 
                                     let rm = lower2[..4].load::<u8>();
-                                    let rotate = lower2[1..3].load::<u8>() << 2;
+                                    let rotate = lower2[4..6].load::<u8>() << 3;
                                     let rd = lower2[8..12].load::<u8>();
 
                                     inst.opcode = op;
                                     inst.operands = [
                                         Operand::Reg(Reg::from_u8(rd)),
                                         Operand::Reg(Reg::from_u8(rm)),
-                                        Operand::Imm32(rotate as u32),
+                                        if rotate != 0 {
+                                            Operand::Imm32(rotate as u32)
+                                        } else {
+                                            Operand::Nothing
+                                        },
                                         Operand::Nothing,
                                     ];
                                 } else {
@@ -2900,12 +2904,12 @@ pub fn decode_into<T: Reader<<ARMv7 as Arch>::Address, <ARMv7 as Arch>::Word>>(d
                                         Opcode::UXTAH,
                                         Opcode::SXTAB16,
                                         Opcode::UXTAB16,
-                                        Opcode::SXTAH,
+                                        Opcode::SXTAB,
                                         Opcode::UXTAB,
                                     ][op1];
 
                                     let rm = lower2[..4].load::<u8>();
-                                    let rotate = lower2[1..3].load::<u8>() << 2;
+                                    let rotate = lower2[4..6].load::<u8>() << 3;
                                     let rd = lower2[8..12].load::<u8>();
 
                                     inst.opcode = op;
@@ -2913,7 +2917,11 @@ pub fn decode_into<T: Reader<<ARMv7 as Arch>::Address, <ARMv7 as Arch>::Word>>(d
                                         Operand::Reg(Reg::from_u8(rd)),
                                         Operand::Reg(Reg::from_u8(rn)),
                                         Operand::Reg(Reg::from_u8(rm)),
-                                        Operand::Imm32(rotate as u32),
+                                        if rotate != 0 {
+                                            Operand::Imm32(rotate as u32)
+                                        } else {
+                                            Operand::Nothing
+                                        },
                                     ];
                                 };
                             }

--- a/src/armv7/thumb.rs
+++ b/src/armv7/thumb.rs
@@ -838,7 +838,7 @@ pub fn decode_into<T: Reader<<ARMv7 as Arch>::Address, <ARMv7 as Arch>::Word>>(d
                                             inst.set_w(false);
                                             let rm = lower2[..4].load::<u8>();
                                             let rd = lower2[8..12].load::<u8>();
-                                            inst.opcode = Opcode::ASR;
+                                            inst.opcode = Opcode::ROR;
                                             inst.operands = [
                                                 Operand::Reg(Reg::from_u8(rd)),
                                                 Operand::Reg(Reg::from_u8(rm)),
@@ -1111,7 +1111,7 @@ pub fn decode_into<T: Reader<<ARMv7 as Arch>::Address, <ARMv7 as Arch>::Word>>(d
                             if rn == 0b1111 {
                                 // `MVN` (`A8-505`)
                                 // v6T2
-                                inst.opcode = Opcode::MOV;
+                                inst.opcode = Opcode::MVN;
                                 inst.operands = [
                                     Operand::Reg(Reg::from_u8(rd)),
                                     Operand::Imm32(imm as u32),
@@ -1292,7 +1292,7 @@ pub fn decode_into<T: Reader<<ARMv7 as Arch>::Address, <ARMv7 as Arch>::Word>>(d
                             inst.opcode = Opcode::MOV;
                             inst.operands = [
                                 Operand::Reg(Reg::from_u8(rd)),
-                                Operand::Imm32(imm as u32 | ((rn as u32) << 16)),
+                                Operand::Imm32(imm as u32 | ((rn as u32) << 12)),
                                 Operand::Nothing,
                                 Operand::Nothing,
                             ];
@@ -1330,7 +1330,7 @@ pub fn decode_into<T: Reader<<ARMv7 as Arch>::Address, <ARMv7 as Arch>::Word>>(d
                             inst.opcode = Opcode::MOVT;
                             inst.operands = [
                                 Operand::Reg(Reg::from_u8(rd)),
-                                Operand::Imm32(imm as u32 | ((rn as u32) << 16)),
+                                Operand::Imm32(imm as u32 | ((rn as u32) << 12)),
                                 Operand::Nothing,
                                 Operand::Nothing,
                             ];
@@ -2023,7 +2023,9 @@ pub fn decode_into<T: Reader<<ARMv7 as Arch>::Address, <ARMv7 as Arch>::Word>>(d
                             match size_bits {
                                 0b00 => {
                                     // `STRB_`
-                                    if op2 == 0 {
+                                    // op2 only selects a form when the imm12 bit is clear;
+                                    // otherwise it's just the high bits of imm12.
+                                    if !has_imm12 && op2 == 0 {
                                         // `STRB (register)` (`A8-683`)
                                         // encoding T2
                                         // v6T2
@@ -2048,7 +2050,7 @@ pub fn decode_into<T: Reader<<ARMv7 as Arch>::Address, <ARMv7 as Arch>::Word>>(d
                                             Operand::Nothing,
                                             Operand::Nothing,
                                         ];
-                                    } else if (op2 & 0b111100) == 0b111000 {
+                                    } else if !has_imm12 && (op2 & 0b111100) == 0b111000 {
                                         // `STRBT` (`A8-685`)
                                         // v6T2
                                         let imm8 = lower & 0b1111_1111;
@@ -2112,7 +2114,7 @@ pub fn decode_into<T: Reader<<ARMv7 as Arch>::Address, <ARMv7 as Arch>::Word>>(d
                                 0b01 => {
                                     // `STRH_`
                                     // v6T2
-                                    if op2 == 0 {
+                                    if !has_imm12 && op2 == 0 {
                                         // `STRH (register)` (`A8-703`)
                                         let rm = (lower & 0b1111) as u8;
                                         let imm2 = (lower >> 4) & 0b11;
@@ -2135,7 +2137,7 @@ pub fn decode_into<T: Reader<<ARMv7 as Arch>::Address, <ARMv7 as Arch>::Word>>(d
                                             Operand::Nothing,
                                             Operand::Nothing,
                                         ];
-                                    } else if (op2 & 0b111100) == 0b111000 {
+                                    } else if !has_imm12 && (op2 & 0b111100) == 0b111000 {
                                         // `STRHT` (`A8-705`)
                                         let imm8 = lower & 0b1111_1111;
                                         let rt = ((lower >> 12) & 0b1111) as u8;
@@ -2197,7 +2199,7 @@ pub fn decode_into<T: Reader<<ARMv7 as Arch>::Address, <ARMv7 as Arch>::Word>>(d
                                 }
                                 0b10 => {
                                     // `STR_`
-                                    if op2 == 0 {
+                                    if !has_imm12 && op2 == 0 {
                                         // `STR (register)` (`A8-677`)
                                         // v6T2
                                         let rm = (lower & 0b1111) as u8;
@@ -2221,7 +2223,7 @@ pub fn decode_into<T: Reader<<ARMv7 as Arch>::Address, <ARMv7 as Arch>::Word>>(d
                                             Operand::Nothing,
                                             Operand::Nothing,
                                         ];
-                                    } else if (op2 & 0b111100) == 0b111000 {
+                                    } else if !has_imm12 && (op2 & 0b111100) == 0b111000 {
                                         // `STRT` (`A8-707`)
                                         let imm8 = lower & 0b1111_1111;
                                         let rt = ((lower >> 12) & 0b1111) as u8;

--- a/tests/armv7/thumb.rs
+++ b/tests/armv7/thumb.rs
@@ -4247,3 +4247,81 @@ fn test_decode_mov_reg_shift_cases() {
         "rrx r3, r2"
     );
 }
+
+#[test]
+fn test_decode_ux_sx_32b_cases() {
+    // rotation is hw1[5:4] scaled by 8, and omitted when zero
+    test_display(
+        &[0x1f, 0xfa, 0x8b, 0xfb],
+        "uxth.w fp, fp"
+    );
+    test_display(
+        &[0x5f, 0xfa, 0x8c, 0xfc],
+        "uxtb.w ip, ip"
+    );
+    test_display(
+        &[0x5f, 0xfa, 0x9c, 0xfc],
+        "uxtb.w ip, ip, 0x8"
+    );
+    test_display(
+        &[0x1f, 0xfa, 0xab, 0xfb],
+        "uxth.w fp, fp, 0x10"
+    );
+    test_display(
+        &[0x0f, 0xfa, 0x82, 0xf1],
+        "sxth.w r1, r2"
+    );
+    test_display(
+        &[0x52, 0xfa, 0x93, 0xf1],
+        "uxtab.w r1, r2, r3, 0x8"
+    );
+    test_display(
+        &[0x42, 0xfa, 0x83, 0xf1],
+        "sxtab.w r1, r2, r3"
+    );
+    test_display(
+        &[0x02, 0xfa, 0x83, 0xf1],
+        "sxtah.w r1, r2, r3"
+    );
+}
+
+#[test]
+fn test_decode_ux_sx_b16_32b_cases() {
+    test_display(
+        &[0x2f, 0xfa, 0x82, 0xf1],
+        "sxtb16.w r1, r2"
+    );
+    test_display(
+        &[0x3f, 0xfa, 0x82, 0xf1],
+        "uxtb16.w r1, r2"
+    );
+    test_display(
+        &[0x22, 0xfa, 0x83, 0xf1],
+        "sxtab16.w r1, r2, r3"
+    );
+    test_display(
+        &[0x32, 0xfa, 0x83, 0xf1],
+        "uxtab16.w r1, r2, r3"
+    );
+}
+
+#[test]
+fn test_decode_shift_reg_32b_cases() {
+    // register-controlled shift: type is in hw0[6:5]
+    test_display(
+        &[0x02, 0xfa, 0x03, 0xf1],
+        "lsl.w r1, r2, r3"
+    );
+    test_display(
+        &[0x22, 0xfa, 0x03, 0xf1],
+        "lsr.w r1, r2, r3"
+    );
+    test_display(
+        &[0x42, 0xfa, 0x03, 0xf1],
+        "asr.w r1, r2, r3"
+    );
+    test_display(
+        &[0x62, 0xfa, 0x03, 0xf1],
+        "ror.w r1, r2, r3"
+    );
+}

--- a/tests/armv7/thumb.rs
+++ b/tests/armv7/thumb.rs
@@ -4325,3 +4325,40 @@ fn test_decode_shift_reg_32b_cases() {
         "ror.w r1, r2, r3"
     );
 }
+
+#[test]
+fn test_decode_tbb_tbh_cases() {
+    test_display(
+        &[0xdf, 0xe8, 0x13, 0xf0],
+        "tbh [pc, r3, lsl 1]"
+    );
+    test_display(
+        &[0xdf, 0xe8, 0x0b, 0xf0],
+        "tbb [pc, fp]"
+    );
+}
+
+#[test]
+fn test_decode_tbh_operand_shape() {
+    use yaxpeax_arm::armv7::{Opcode, Operand, RegShiftStyle, ShiftStyle};
+
+    let mut reader = yaxpeax_arch::U8Reader::new(&[0xdf, 0xe8, 0x13, 0xf0][..]);
+    let inst = InstDecoder::default_thumb().decode(&mut reader).unwrap();
+    assert_eq!(inst.opcode, Opcode::TBH);
+    match inst.operands[0] {
+        Operand::RegDerefPreindexRegShift(base, shift, add, wback) => {
+            assert_eq!(base.number(), 15);
+            assert!(add);
+            assert!(!wback);
+            match shift.into_shift() {
+                RegShiftStyle::RegImm(s) => {
+                    assert_eq!(s.shiftee().number(), 3);
+                    assert_eq!(s.stype(), ShiftStyle::LSL);
+                    assert_eq!(s.imm(), 1);
+                }
+                RegShiftStyle::RegReg(_) => panic!("TBH index must be a register+immediate shift"),
+            }
+        }
+        other => panic!("unexpected TBH operand: {:?}", other),
+    }
+}

--- a/tests/armv7/thumb.rs
+++ b/tests/armv7/thumb.rs
@@ -4136,3 +4136,114 @@ fn test_decode_simd_32b_cases() {
         "vstmdb r3!, {s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31}"
     );
 }
+
+#[test]
+fn test_decode_str_32b_imm12_cases() {
+    // bit 23 selects the imm12 form; low imm12 bits are not the register-offset
+    // or strbt/strht/strt forms.
+    test_display(
+        &[0x83, 0xf8, 0x21, 0x20],
+        "strb.w r2, [r3, 0x21]"
+    );
+    test_display(
+        &[0x83, 0xf8, 0x3f, 0x20],
+        "strb.w r2, [r3, 0x3f]"
+    );
+    test_display(
+        &[0xa3, 0xf8, 0x21, 0x20],
+        "strh.w r2, [r3, 0x21]"
+    );
+    test_display(
+        &[0xc3, 0xf8, 0x21, 0x20],
+        "str.w r2, [r3, 0x21]"
+    );
+    test_display(
+        &[0x83, 0xf8, 0x21, 0x2e],
+        "strb.w r2, [r3, 0xe21]"
+    );
+    test_display(
+        &[0x83, 0xf8, 0x40, 0x20],
+        "strb.w r2, [r3, 0x40]"
+    );
+    test_display(
+        &[0xcd, 0xf8, 0x0c, 0xc0],
+        "str.w ip, [sp, 0xc]"
+    );
+    test_display(
+        &[0xd3, 0xf8, 0x21, 0x20],
+        "ldr.w r2, [r3, 0x21]"
+    );
+    test_display(
+        &[0x93, 0xf8, 0x05, 0x10],
+        "ldrb.w r1, [r3, 0x5]"
+    );
+    test_display(
+        &[0xb3, 0xf8, 0x08, 0x10],
+        "ldrh.w r1, [r3, 0x8]"
+    );
+}
+
+#[test]
+fn test_decode_movw_movt_cases() {
+    // imm16 is imm4:i:imm3:imm8
+    test_display(
+        &[0xcf, 0xf2, 0x05, 0x04],
+        "movt r4, 0xf005"
+    );
+    test_display(
+        &[0x4f, 0xf2, 0x05, 0x00],
+        "mov r0, 0xf005"
+    );
+    test_display(
+        &[0x40, 0xf2, 0x34, 0x12],
+        "mov r2, 0x134"
+    );
+    test_display(
+        &[0xc0, 0xf2, 0x01, 0x00],
+        "movt r0, 0x1"
+    );
+}
+
+#[test]
+fn test_decode_mvn_imm_cases() {
+    test_display(
+        &[0x6f, 0xf0, 0x40, 0x41],
+        "mvn.w r1, 0xc0000000"
+    );
+    test_display(
+        &[0x6f, 0xf0, 0x7f, 0x40],
+        "mvn.w r0, 0xff000000"
+    );
+    test_display(
+        &[0x6f, 0xf0, 0x01, 0x01],
+        "mvn.w r1, 0x1"
+    );
+    test_display(
+        &[0x7f, 0xf0, 0x40, 0x41],
+        "mvns.w r1, 0xc0000000"
+    );
+}
+
+#[test]
+fn test_decode_mov_reg_shift_cases() {
+    test_display(
+        &[0x4f, 0xea, 0xfc, 0x49],
+        "ror sb, ip, 0x13"
+    );
+    test_display(
+        &[0x4f, 0xea, 0x31, 0x42],
+        "ror r2, r1, 0x10"
+    );
+    test_display(
+        &[0x4f, 0xea, 0x72, 0x12],
+        "ror r2, r2, 0x5"
+    );
+    test_display(
+        &[0x4f, 0xea, 0x51, 0x01],
+        "lsr.w r1, r1, 0x1"
+    );
+    test_display(
+        &[0x4f, 0xea, 0x32, 0x03],
+        "rrx r3, r2"
+    );
+}


### PR DESCRIPTION
- 32-bit store encodings with the imm12 bit (bit 23) set were decoded as the register-offset form when imm12 < 64, or as strbt/strht/strt when imm12 was 0xExx. bit 23 set always means the imm12 form.
- movw/movt packed imm4 at bit 16 instead of bit 12, producing 20-bit immediates (e.g. 0xf0005 instead of 0xf005)
- mvn (immediate) was decoded as mov, dropping the bitwise not
- ror (immediate) was decoded as asr

all cases verified against binutils objdump