### PR TITLE
Fix branch instructions offset

### DIFF
--- a/src/armv7/thumb.rs
+++ b/src/armv7/thumb.rs
@@ -1970,7 +1970,7 @@ pub fn decode_into<T: Reader<<ARMv7 as Arch>::Address, <ARMv7 as Arch>::Word>>(d
                         ((i2 as i32) << 21) |
                         ((i1 as i32) << 22) |
                         ((s as i32) << 23);
-                    let imm = (imm << 8) >> 8;
+                    let imm = (imm << 8) >> 7;
                     inst.operands = [
                         Operand::BranchThumbOffset(imm),
                         Operand::Nothing,

--- a/src/armv7/thumb.rs
+++ b/src/armv7/thumb.rs
@@ -4031,7 +4031,7 @@ pub fn decode_into<T: Reader<<ARMv7 as Arch>::Address, <ARMv7 as Arch>::Word>>(d
                 let imm = instr2[0..8].load::<u8>() as i8 as i32;
                 inst.condition = ConditionCode::build(opcode);
                 inst.operands = [
-                    Operand::BranchThumbOffset(imm + 1),
+                    Operand::BranchThumbOffset(imm << 1),
                     Operand::Nothing,
                     Operand::Nothing,
                     Operand::Nothing,


### PR DESCRIPTION
## For `b`
`imm8:'0'` should be translated to a left shift, not an addition

<img width="1009" height="342" alt="image" src="https://github.com/user-attachments/assets/8a659f37-d931-414d-8351-07e7c9e3df61" />

## For `bl`

The `:'0'` in `S:I1:I2:imm10:imm11:’0’` wasn't implemented, so the `imm` needs to be shifted left by one.

<img width="1184" height="385" alt="image" src="https://github.com/user-attachments/assets/96ac0e51-e3d8-4deb-bee5-425188728b02" />

